### PR TITLE
Adding a BlsAccount class for creating a bls wallet

### DIFF
--- a/ethdk/.eslintrc.js
+++ b/ethdk/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     project: './tsconfig.json',
     tsconfigRootDir: __dirname
   },
-  ignorePatterns: ['test/**/*', 'dist/**/*', 'node_modules/**/*'],
+  ignorePatterns: ['dist/**/*', 'node_modules/**/*'],
   rules: {
     indent: ['error', 2]
   }

--- a/ethdk/README.md
+++ b/ethdk/README.md
@@ -1,3 +1,35 @@
 # ethdk
 
 Ethdk is meant to make interacting with the Ethereum ecosystem easier for developers by abstracting the web3 domain knowledge into an easy-to-understand node module.
+
+## Getting started
+How to use ethdk
+### Accounts
+
+```typescript
+import { createAccount, generatePrivateKey } from "ethdk";
+
+const privateKey = await generatePrivateKey('bls');
+
+// Private key param is optional. A random private key will
+// be generated if one is not provided.
+const account = createAccount('bls', privateKey); 
+
+const { address } = account;
+
+```
+
+#### Recovery
+
+```typescript
+const recoveryPhrase = 'Do not forget this!';
+const trustedAccount = '0x70b8...06A0';
+account.setTrustedAccount(recoveryPhrase, trustedAccount);
+```
+
+### Transaction
+
+```typescript
+const transactionHash = await account.sendTransaction(...);
+                                            
+```

--- a/ethdk/src/BlsAccount.ts
+++ b/ethdk/src/BlsAccount.ts
@@ -42,6 +42,11 @@ export default class BlsAccount implements Account {
     return await BlsWalletWrapper.getRandomBlsPrivateKey()
   }
 
+  /**
+   * Sends a transaction to the aggregator to be bundled and submitted to the L2
+   * @param params Array of transactions
+   * @returns Transaction hash of the transaction that was sent to the aggregator
+   */
   async sendTransaction (params: SendTransactionParams[]): Promise<string> {
     const actions = params.map((tx) => ({
       ethValue: tx.value ?? '0',
@@ -55,6 +60,13 @@ export default class BlsAccount implements Account {
     return await addBundleToAggregator(bundle)
   }
 
+  /**
+   * Sets the trusted account for this account. The trusted account will be able to reset this accounts private key
+   * by calling the recoverWallet function using this accounts address and the recovery phrase.
+   * @param recoveryPhrase String that is used as salt to generate the recovery hash
+   * @param trustedAccountAddress Address of the account that will be able to reset this accounts private key
+   * @returns Transaction hash of the transaction that was sent to the aggregator
+   */
   async setTrustedAccount (recoveryPhrase: string, trustedAccountAddress: string): Promise<string> {
     const bundle = await this.wallet.getSetRecoveryHashBundle(
       recoveryPhrase,

--- a/ethdk/src/BlsAccount.ts
+++ b/ethdk/src/BlsAccount.ts
@@ -1,0 +1,77 @@
+import { BlsWalletWrapper, Aggregator, type Bundle } from 'bls-wallet-clients'
+import { ethers } from 'ethers'
+import type Account from './interfaces/Account'
+import type SendTransactionParams from './interfaces/SendTransactionParams'
+
+// Initially we are just using the local network. This will be replaced with a
+// dynamic network selection in the future.
+const NETWORK = {
+  name: 'localhost',
+  chainId: '31337',
+  rpcUrl: 'http://localhost:8545',
+  aggregatorUrl: 'http://localhost:3000',
+  verificationGateway: '0x689A095B4507Bfa302eef8551F90fB322B3451c6'
+}
+
+export default class BlsAccount implements Account {
+  public static accountType: string = 'bls'
+
+  address: string
+  private readonly privateKey: string
+  private readonly wallet: BlsWalletWrapper
+
+  private constructor (privateKey: string, wallet: BlsWalletWrapper) {
+    this.privateKey = privateKey
+    this.wallet = wallet
+    this.address = wallet.address
+  }
+
+  static async createAccount (privateKey?: string): Promise<BlsAccount> {
+    const pk = privateKey ?? await BlsWalletWrapper.getRandomBlsPrivateKey()
+
+    const wallet = await BlsWalletWrapper.connect(
+      pk,
+      NETWORK.verificationGateway,
+      new ethers.providers.JsonRpcProvider(NETWORK.rpcUrl)
+    )
+
+    return new BlsAccount(pk, wallet)
+  }
+
+  static async generatePrivateKey (): Promise<string> {
+    return await BlsWalletWrapper.getRandomBlsPrivateKey()
+  }
+
+  async sendTransaction (params: SendTransactionParams[]): Promise<string> {
+    const actions = params.map((tx) => ({
+      ethValue: tx.value ?? '0',
+      contractAddress: tx.to,
+      encodedFunction: tx.data ?? '0x'
+    }))
+
+    const nonce = await this.wallet.Nonce()
+    const bundle = this.wallet.sign({ nonce, actions })
+
+    return await addBundleToAggregator(bundle)
+  }
+
+  async setTrustedAccount (recoveryPhrase: string, trustedAccountAddress: string): Promise<string> {
+    const bundle = await this.wallet.getSetRecoveryHashBundle(
+      recoveryPhrase,
+      trustedAccountAddress
+    )
+
+    return await addBundleToAggregator(bundle)
+  }
+}
+
+async function addBundleToAggregator (bundle: Bundle): Promise<string> {
+  const agg = new Aggregator(NETWORK.aggregatorUrl)
+  const result = await agg.add(bundle)
+
+  if ('failures' in result) {
+    throw new Error(JSON.stringify(result))
+  }
+
+  return result.hash
+}

--- a/ethdk/src/Ethdk.ts
+++ b/ethdk/src/Ethdk.ts
@@ -1,0 +1,16 @@
+import BlsAccount from './BlsAccount'
+import type Account from './interfaces/Account'
+
+export async function createAccount (accountType: string, privateKey?: string): Promise<Account> {
+  if (accountType === BlsAccount.accountType) {
+    return await BlsAccount.createAccount(privateKey)
+  }
+  throw new Error('Unsupported account type')
+}
+
+export async function generatePrivateKey (accountType: string): Promise<string> {
+  if (accountType === BlsAccount.accountType) {
+    return await BlsAccount.generatePrivateKey()
+  }
+  throw new Error('Unsupported account type')
+}

--- a/ethdk/src/Ethdk.ts
+++ b/ethdk/src/Ethdk.ts
@@ -1,6 +1,12 @@
 import BlsAccount from './BlsAccount'
 import type Account from './interfaces/Account'
 
+/**
+ * Creates an account of the specified type
+ * @param accountType The type of account to create ('bls', 'eoa', etc.)
+ * @param privateKey Optional private key to use for the account
+ * @returns An account of the specified type
+ */
 export async function createAccount (accountType: string, privateKey?: string): Promise<Account> {
   if (accountType === BlsAccount.accountType) {
     return await BlsAccount.createAccount(privateKey)
@@ -8,6 +14,11 @@ export async function createAccount (accountType: string, privateKey?: string): 
   throw new Error('Unsupported account type')
 }
 
+/**
+ * Generates a private key of the specified type
+ * @param accountType The type of account to create ('bls', 'eoa', etc.)
+ * @returns A private key of the specified type
+ */
 export async function generatePrivateKey (accountType: string): Promise<string> {
   if (accountType === BlsAccount.accountType) {
     return await BlsAccount.generatePrivateKey()

--- a/ethdk/src/index.ts
+++ b/ethdk/src/index.ts
@@ -1,7 +1,6 @@
-const test = (): void => {
-  console.log('This is a test')
-}
+import { createAccount, generatePrivateKey } from './Ethdk'
 
 export {
-  test
+  createAccount,
+  generatePrivateKey
 }

--- a/ethdk/src/interfaces/Account.ts
+++ b/ethdk/src/interfaces/Account.ts
@@ -1,4 +1,6 @@
+import type SendTransactionParams from './SendTransactionParams'
+
 export default interface Account {
   address: string
-  sendTransaction: (params: any) => Promise<string>
+  sendTransaction: (params: SendTransactionParams[]) => Promise<string>
 }

--- a/ethdk/src/interfaces/Account.ts
+++ b/ethdk/src/interfaces/Account.ts
@@ -1,0 +1,4 @@
+export default interface Account {
+  address: string
+  sendTransaction: (params: any) => Promise<string>
+}

--- a/ethdk/src/interfaces/SendTransactionParams.ts
+++ b/ethdk/src/interfaces/SendTransactionParams.ts
@@ -1,0 +1,8 @@
+export default interface SendTransactionParams {
+  to: string
+  from?: string
+  gas?: string
+  gasPrice?: string
+  value?: string
+  data?: string
+}

--- a/ethdk/test/index.test.ts
+++ b/ethdk/test/index.test.ts
@@ -1,7 +1,11 @@
+import { generatePrivateKey } from '../src/Ethdk';
 import { expect } from 'chai';
 
-describe('test', () => {
-    it('should return test', () => {
-        expect('test').to.equal('test');
-    });
+describe('Ethdk', () => {
+  it('should create a bls private key', async () => {
+    const privateKey = await generatePrivateKey('bls');
+    // Private key should be a hex string of length 66
+    const privateKeyRegex = /^0x[0-9a-fA-F]{64}$/;
+    expect(privateKey).to.match(privateKeyRegex);
+  });
 });

--- a/ethdk/test/index.test.ts
+++ b/ethdk/test/index.test.ts
@@ -1,11 +1,11 @@
-import { generatePrivateKey } from '../src/Ethdk';
-import { expect } from 'chai';
+import { generatePrivateKey } from '../src/Ethdk'
+import { expect } from 'chai'
 
 describe('Ethdk', () => {
   it('should create a bls private key', async () => {
-    const privateKey = await generatePrivateKey('bls');
+    const privateKey = await generatePrivateKey('bls')
     // Private key should be a hex string of length 66
-    const privateKeyRegex = /^0x[0-9a-fA-F]{64}$/;
-    expect(privateKey).to.match(privateKeyRegex);
-  });
-});
+    const privateKeyRegex = /^0x[0-9a-fA-F]{64}$/
+    expect(privateKey).to.match(privateKeyRegex)
+  })
+})

--- a/ethdk/test/init.ts
+++ b/ethdk/test/init.ts
@@ -1,4 +1,4 @@
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
 
-chai.use(chaiAsPromised);
+chai.use(chaiAsPromised)

--- a/ethdk/tsconfig.json
+++ b/ethdk/tsconfig.json
@@ -15,11 +15,11 @@
       "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
     },
     "include": [
-      "src/**/*"
+      "src/**/*",
+      "test/**/*"
     ],
     "exclude": [
       "node_modules",
-      "test",
       "dist"
     ]
   }


### PR DESCRIPTION
This PR is for a proof-of-concept version of ethdk.  I'm open to any feedback on structure and I'm happy to make updates.  Note this version is hardcoded to use the local network.  I plan to make it dynamic in a future PR.

This PR includes
- generating a random BLS private key
- Creating a `blsAccount` object
- Sending a tx from an account
- setting a trusted account for recovery

Tickets I created for work to come:
- Testing: we will need a good way to mock the bls-wallet-clients module: [ticket](https://github.com/web3well/ethdk/issues/7) 
- Create a Transaction class: [ticket](https://github.com/web3well/ethdk/issues/8)
- Add a function to get the account status (eg: balance, trusted wallet set, account recovered): [ticket](https://github.com/web3well/ethdk/issues/9)