### PR TITLE
Add transaction class

### DIFF
--- a/ethdk/src/BlsAccount.ts
+++ b/ethdk/src/BlsAccount.ts
@@ -10,7 +10,7 @@ import { type BlsNetwork } from './interfaces/Network'
 // replaced with a dynamic network selection in the future.
 const NETWORK: BlsNetwork = {
   name: 'localhost',
-  chainId: '31337',
+  chainId: 31337,
   rpcUrl: 'http://localhost:8545',
   aggregatorUrl: 'http://localhost:3000',
   verificationGateway: '0x689A095B4507Bfa302eef8551F90fB322B3451c6'

--- a/ethdk/src/BlsAccount.ts
+++ b/ethdk/src/BlsAccount.ts
@@ -1,11 +1,14 @@
 import { BlsWalletWrapper, Aggregator, type Bundle } from 'bls-wallet-clients'
 import { ethers } from 'ethers'
+import BlsTransaction from './BlsTransaction'
+import type Transaction from './interfaces/Transaction'
 import type Account from './interfaces/Account'
 import type SendTransactionParams from './interfaces/SendTransactionParams'
+import { type BlsNetwork } from './interfaces/Network'
 
-// Initially we are just using the local network. This will be replaced with a
-// dynamic network selection in the future.
-const NETWORK = {
+// TODO (ethdk #10) Initially we are just using the local network. This will be
+// replaced with a dynamic network selection in the future.
+const NETWORK: BlsNetwork = {
   name: 'localhost',
   chainId: '31337',
   rpcUrl: 'http://localhost:8545',
@@ -14,7 +17,7 @@ const NETWORK = {
 }
 
 export default class BlsAccount implements Account {
-  public static accountType: string = 'bls'
+  static accountType: string = 'bls'
 
   address: string
   private readonly privateKey: string
@@ -47,7 +50,7 @@ export default class BlsAccount implements Account {
    * @param params Array of transactions
    * @returns Transaction hash of the transaction that was sent to the aggregator
    */
-  async sendTransaction (params: SendTransactionParams[]): Promise<string> {
+  async sendTransaction (params: SendTransactionParams[]): Promise<Transaction> {
     const actions = params.map((tx) => ({
       ethValue: tx.value ?? '0',
       contractAddress: tx.to,
@@ -67,7 +70,7 @@ export default class BlsAccount implements Account {
    * @param trustedAccountAddress Address of the account that will be able to reset this accounts private key
    * @returns Transaction hash of the transaction that was sent to the aggregator
    */
-  async setTrustedAccount (recoveryPhrase: string, trustedAccountAddress: string): Promise<string> {
+  async setTrustedAccount (recoveryPhrase: string, trustedAccountAddress: string): Promise<Transaction> {
     const bundle = await this.wallet.getSetRecoveryHashBundle(
       recoveryPhrase,
       trustedAccountAddress
@@ -75,9 +78,20 @@ export default class BlsAccount implements Account {
 
     return await addBundleToAggregator(bundle)
   }
+
+  /**
+   * Get the balance of this account
+   * @returns The balance of this account formated in ether (instead of wei)
+   */
+  async getBalance (): Promise<string> {
+    const provider = new ethers.providers.JsonRpcProvider(NETWORK.rpcUrl)
+    const balance = await provider.getBalance(this.address)
+
+    return ethers.utils.formatEther(balance)
+  }
 }
 
-async function addBundleToAggregator (bundle: Bundle): Promise<string> {
+async function addBundleToAggregator (bundle: Bundle): Promise<Transaction> {
   const agg = new Aggregator(NETWORK.aggregatorUrl)
   const result = await agg.add(bundle)
 
@@ -85,5 +99,5 @@ async function addBundleToAggregator (bundle: Bundle): Promise<string> {
     throw new Error(JSON.stringify(result))
   }
 
-  return result.hash
+  return new BlsTransaction(NETWORK, result.hash)
 }

--- a/ethdk/src/BlsTransaction.ts
+++ b/ethdk/src/BlsTransaction.ts
@@ -1,0 +1,24 @@
+import { Aggregator } from 'bls-wallet-clients'
+import { type BundleReceipt, type BundleReceiptError } from 'bls-wallet-clients/dist/src/Aggregator'
+import type Transaction from './interfaces/Transaction'
+import type { BlsNetwork } from './interfaces/Network'
+
+export default class BlsTransaction implements Transaction {
+  hash: string
+  network: BlsNetwork
+
+  constructor (network: BlsNetwork, bundleHash: string) {
+    this.network = network
+    this.hash = bundleHash
+  }
+
+  async getTransactionReceipt (): Promise<BundleReceipt | BundleReceiptError | undefined> {
+    const aggregator = new Aggregator(this.network.aggregatorUrl)
+    return await aggregator.lookupReceipt(this.hash)
+  }
+
+  /**
+   * TODO (ethdk #11) Add in the BLS provider for better transaction functionality
+   * eg: polling for transaction receipt
+   */
+}

--- a/ethdk/src/interfaces/Account.ts
+++ b/ethdk/src/interfaces/Account.ts
@@ -1,6 +1,7 @@
 import type SendTransactionParams from './SendTransactionParams'
+import type Transaction from './Transaction'
 
 export default interface Account {
   address: string
-  sendTransaction: (params: SendTransactionParams[]) => Promise<string>
+  sendTransaction: (params: SendTransactionParams[]) => Promise<Transaction>
 }

--- a/ethdk/src/interfaces/Network.ts
+++ b/ethdk/src/interfaces/Network.ts
@@ -1,6 +1,6 @@
 export interface Network {
   name: string
-  chainId: string
+  chainId: number
   rpcUrl: string
 }
 

--- a/ethdk/src/interfaces/Network.ts
+++ b/ethdk/src/interfaces/Network.ts
@@ -1,0 +1,10 @@
+export interface Network {
+  name: string
+  chainId: string
+  rpcUrl: string
+}
+
+export interface BlsNetwork extends Network {
+  aggregatorUrl: string
+  verificationGateway: string
+}

--- a/ethdk/src/interfaces/Transaction.ts
+++ b/ethdk/src/interfaces/Transaction.ts
@@ -1,0 +1,3 @@
+export default interface Transaction {
+  hash: string
+}


### PR DESCRIPTION
Intentionally keeping this PR pretty simple.  I added a very slim transaction class.  I wanted to hold off on doing more complex functionality until we add the BlsProvider and BlsSigner (I've added a ticket to do this soon).

I also added a get balance method to the BlsAccount.  At this point, ethdk has all the functionality that the instant wallet uses.  This will a good point to add testing, clean up the code with the bls provider/signer I mentioned above, and think about additional functionality we can expose.