### PR TITLE
Adding tests for BlsAccount and BlsTransaction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ethdk
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run tests
+        run: yarn test

--- a/ethdk/package.json
+++ b/ethdk/package.json
@@ -25,6 +25,7 @@
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^10.0.1",
+    "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
@@ -34,6 +35,7 @@
     "eslint-plugin-n": "^15.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "mocha": "^10.2.0",
+    "sinon": "^15.0.2",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.1",
     "typescript": "*"

--- a/ethdk/src/BlsTransaction.ts
+++ b/ethdk/src/BlsTransaction.ts
@@ -13,8 +13,12 @@ export default class BlsTransaction implements Transaction {
   }
 
   async getTransactionReceipt (): Promise<BundleReceipt | BundleReceiptError | undefined> {
-    const aggregator = new Aggregator(this.network.aggregatorUrl)
+    const aggregator = this.getAggregator()
     return await aggregator.lookupReceipt(this.hash)
+  }
+
+  private getAggregator (): Aggregator {
+    return new Aggregator(this.network.aggregatorUrl)
   }
 
   /**

--- a/ethdk/test/BlsAccount.test.ts
+++ b/ethdk/test/BlsAccount.test.ts
@@ -1,0 +1,131 @@
+import { expect } from 'chai'
+import { describe, it, afterEach } from 'mocha'
+import BlsAccount from '../src/BlsAccount'
+import sinon from 'sinon'
+
+import { ethers } from 'ethers'
+import { BlsWalletWrapper, Aggregator } from 'bls-wallet-clients'
+
+describe('BlsAccount', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('createAccount', () => {
+    it('should create an account with a given private key', async () => {
+      const privateKey = '0x123'
+      const mockWallet: any = { address: '0x12345' }
+
+      sinon.stub(BlsWalletWrapper, 'connect').resolves(mockWallet)
+
+      const account = await BlsAccount.createAccount(privateKey)
+
+      expect(account).to.be.instanceOf(BlsAccount)
+      expect(account.address).to.equal(mockWallet.address)
+    })
+
+    it('should create an account with a generated private key', async () => {
+      const privateKey = '0x123'
+      const mockWallet: any = { address: '0x12345' }
+
+      sinon.stub(BlsWalletWrapper, 'connect').resolves(mockWallet)
+      sinon.stub(BlsWalletWrapper, 'getRandomBlsPrivateKey').resolves(privateKey)
+
+      const account = await BlsAccount.createAccount()
+
+      expect(account).to.be.instanceOf(BlsAccount)
+      expect(account.address).to.equal(mockWallet.address)
+    })
+  })
+
+  describe('generatePrivateKey', () => {
+    it('should return a generated private key', async () => {
+      const privateKey = '0x123'
+
+      sinon.stub(BlsWalletWrapper, 'getRandomBlsPrivateKey').resolves(privateKey)
+
+      const result = await BlsAccount.generatePrivateKey()
+
+      expect(result).to.equal(privateKey)
+    })
+  })
+
+  describe('sendTransaction', () => {
+    it('should send a transaction successfully', async () => {
+      const mockBundle = { some: 'bundle' }
+      const mockWallet: any = {
+        address: '0x12345',
+        sign: () => mockBundle,
+        Nonce: () => 0
+      }
+      sinon.stub(BlsWalletWrapper, 'connect').resolves(mockWallet)
+      const account = await BlsAccount.createAccount('0x123')
+      const params = [
+        {
+          to: '0x12345',
+          value: '0',
+          data: '0x'
+        }
+      ]
+
+      const mockResult = { hash: '0x67890' }
+
+      const mockAggregator = sinon.createStubInstance(Aggregator)
+      mockAggregator.add.resolves(mockResult)
+      // Stub the getProvider function to return the mockProvider
+      sinon.stub(BlsAccount.prototype, 'getAggregator' as any).returns(mockAggregator as any)
+
+      const transaction = await account.sendTransaction(params)
+
+      expect(transaction.hash).to.equal(mockResult.hash)
+    })
+  })
+
+  describe('setTrustedAccount', () => {
+    it('should set a trusted account successfully', async () => {
+      const mockBundle = { some: 'bundle' }
+      const mockWallet: any = {
+        address: '0x12345',
+        getSetRecoveryHashBundle: () => mockBundle
+      }
+
+      sinon.stub(BlsWalletWrapper, 'connect').resolves(mockWallet)
+      const account = await BlsAccount.createAccount('0x123')
+      const recoveryPhrase = 'some_recovery_phrase'
+      const trustedAccountAddress = '0x12345'
+
+      const mockResult = { hash: '0x67890' }
+
+      const mockAggregator = sinon.createStubInstance(Aggregator)
+      mockAggregator.add.resolves(mockResult)
+      // Stub the getProvider function to return the mockProvider
+      sinon.stub(BlsAccount.prototype, 'getAggregator' as any).returns(mockAggregator as any)
+
+      const transaction = await account.setTrustedAccount(recoveryPhrase, trustedAccountAddress)
+
+      expect(transaction.hash).to.equal(mockResult.hash)
+    })
+  })
+
+  describe('getBalance', () => {
+    it('should return the account balance formatted in ether', async () => {
+      const privateKey = '0x123'
+      const mockWallet: any = { address: '0x12345' }
+
+      sinon.stub(BlsWalletWrapper, 'connect').resolves(mockWallet)
+
+      const account = await BlsAccount.createAccount(privateKey)
+
+      const mockBalance = ethers.utils.parseEther('10')
+      const mockProvider = sinon.createStubInstance(ethers.providers.JsonRpcProvider)
+      mockProvider.getBalance.resolves(mockBalance)
+
+      // Stub the getProvider function to return the mockProvider
+      sinon.stub(BlsAccount.prototype, 'getProvider' as any).resolves(mockProvider as any)
+
+      const balance = await account.getBalance()
+
+      expect(balance).to.equal('10.0')
+    })
+  })
+})

--- a/ethdk/test/BlsTransaction.test.ts
+++ b/ethdk/test/BlsTransaction.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { Aggregator } from 'bls-wallet-clients'
+import BlsTransaction from '../src/BlsTransaction'
+import type { BlsNetwork } from '../src/interfaces/Network'
+
+describe('BlsTransaction', () => {
+  const network: BlsNetwork = {
+    name: 'localhost',
+    chainId: 31337,
+    rpcUrl: 'http://localhost:8545',
+    aggregatorUrl: 'http://localhost:3000',
+    verificationGateway: '0x689A095B4507Bfa302eef8551F90fB322B3451c6'
+  }
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('getTransactionReceipt', () => {
+    it('should return the transaction receipt', async () => {
+      const bundleHash = 'testBundleHash'
+      const mockReceipt: any = {
+        bundleHash
+      }
+
+      const mockAggregator = sinon.createStubInstance(Aggregator)
+      mockAggregator.lookupReceipt.resolves(mockReceipt)
+
+      // Stub the getAggregator function to return the mockAggregator
+      sinon.stub(BlsTransaction.prototype, 'getAggregator' as any).returns(mockAggregator as any)
+
+      const transaction = new BlsTransaction(network, bundleHash)
+
+      const receipt = await transaction.getTransactionReceipt()
+
+      expect(receipt).to.deep.equal(mockReceipt)
+      expect(mockAggregator.lookupReceipt.calledOnceWith(bundleHash)).to.equal(true)
+    })
+  })
+})

--- a/ethdk/yarn.lock
+++ b/ethdk/yarn.lock
@@ -429,6 +429,41 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@sinonjs/commons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
+  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz#d10549ed1f423d80639c528b6c7f5a1017747d0c"
+  integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+
+"@sinonjs/samsam@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-7.0.1.tgz#5b5fa31c554636f78308439d220986b9523fc51f"
+  integrity sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
+  integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
 "@thehubbleproject/bls@^0.5.1":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@thehubbleproject/bls/-/bls-0.5.1.tgz#6b0565f56fc9c8896dcf3c8f0e2214b69a06167f"
@@ -488,6 +523,18 @@
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
+"@types/sinon@^10.0.13":
+  version "10.0.13"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.13.tgz#60a7a87a70d9372d0b7b38cc03e825f46981fb83"
+  integrity sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
+  integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
 
 "@typescript-eslint/eslint-plugin@^5.0.0":
   version "5.53.0"
@@ -916,6 +963,11 @@ diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+diff@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1734,6 +1786,11 @@ is-weakref@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1773,6 +1830,11 @@ json5@^1.0.2:
   dependencies:
     minimist "^1.2.0"
 
+just-extend@^4.0.2:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -1787,6 +1849,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -1919,6 +1986,17 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+nise@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.4.tgz#491ce7e7307d4ec546f5a659b2efe94a18b4bbc0"
+  integrity sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -2019,6 +2097,13 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -2175,6 +2260,18 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+sinon@^15.0.2:
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-15.0.2.tgz#f3e3aacb990bbaa8a7bb976e86118c5dc0154e66"
+  integrity sha512-PCVP63XZkg0/LOqQH5rEU4LILuvTFMb5tNxTHfs6VUMNnZz2XrnGSTZbAGITjzwQWbl/Bl/8hi4G3zZWjyBwHg==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@sinonjs/samsam" "^7.0.1"
+    diff "^5.1.0"
+    nise "^5.1.4"
+    supports-color "^7.2.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -2244,7 +2341,7 @@ supports-color@8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -2321,7 +2418,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
Adding tests for BlsAccount and BlsTransaction.

Using mocha and chai to be consistent with bls-wallet-clients set up.  I also added Sinon to mock all external calls.