### PR TITLE
Cleaning up the network setup

### DIFF
--- a/ethdk/README.md
+++ b/ethdk/README.md
@@ -13,13 +13,13 @@ How to use ethdk
 ### Accounts
 
 ```typescript
-import { createAccount } from 'ethdk'
+import { networks, createAccount } from 'ethdk'
 
 // Private key param is optional. A random private key will
 // be generated if one is not provided.
-const account = createAccount({
+const account = await createAccount({
   accountType: 'bls',
-  network: 'localhost',
+  network: networks.BLS_NETWORKS.localhost,
 })
 
 const { address } = account

--- a/ethdk/package.json
+++ b/ethdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethdk",
-  "version": "0.1.0",
+  "version": "0.0.0-beta.4",
   "description": "A package meant to make it easier to interact with the Ethereum blockchain.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/ethdk/src/Bls/BlsAccount.ts
+++ b/ethdk/src/Bls/BlsAccount.ts
@@ -10,7 +10,7 @@ import { type Deferrable } from 'ethers/lib/utils'
 import BlsTransaction from './BlsTransaction'
 import type Transaction from '../interfaces/Transaction'
 import type Account from '../interfaces/Account'
-import { type BlsNetwork } from '../interfaces/Network'
+import { type BlsNetwork, type Network } from '../interfaces/Network'
 import { getNetwork } from './BlsNetworks'
 
 export default class BlsAccount implements Account {
@@ -47,7 +47,7 @@ export default class BlsAccount implements Account {
     network,
   }: {
     privateKey?: string
-    network?: string
+    network?: Network
   }): Promise<BlsAccount> {
     const privateKey = pk ?? (await BlsWalletWrapper.getRandomBlsPrivateKey())
     const networkConfig = getNetwork(network)
@@ -87,7 +87,7 @@ export default class BlsAccount implements Account {
   ): Promise<Transaction> {
     const response = await this.blsSigner.sendTransaction(transaction)
     return new BlsTransaction({
-      network: this.networkConfig.name,
+      network: this.networkConfig,
       bundleHash: response.hash,
     })
   }
@@ -116,7 +116,7 @@ export default class BlsAccount implements Account {
     return await addBundleToAggregator(
       this.getAggregator(),
       bundle,
-      this.networkConfig.name,
+      this.networkConfig,
     )
   }
 
@@ -153,7 +153,7 @@ export default class BlsAccount implements Account {
     return await addBundleToAggregator(
       this.getAggregator(),
       bundle,
-      this.networkConfig.name,
+      this.networkConfig,
     )
   }
 
@@ -174,7 +174,7 @@ export default class BlsAccount implements Account {
 async function addBundleToAggregator(
   agg: Aggregator,
   bundle: Bundle,
-  network: string,
+  network: BlsNetwork,
 ): Promise<Transaction> {
   const result = await agg.add(bundle)
 

--- a/ethdk/src/Bls/BlsNetworks.ts
+++ b/ethdk/src/Bls/BlsNetworks.ts
@@ -1,6 +1,7 @@
-import { type BlsNetwork } from '../interfaces/Network'
+import { type Network, type BlsNetwork } from '../interfaces/Network'
 
-const localhost: BlsNetwork = {
+export const localhost: BlsNetwork = {
+  type: 'bls',
   name: 'localhost',
   chainId: 1337,
   rpcUrl: 'http://localhost:8545',
@@ -9,13 +10,13 @@ const localhost: BlsNetwork = {
   verificationGateway: '0x689A095B4507Bfa302eef8551F90fB322B3451c6',
 }
 
-const NETWORKS = {
-  localhost,
-}
-
-export function getNetwork(name?: string): BlsNetwork {
-  if (name === 'localhost' || name === undefined) {
-    return NETWORKS.localhost
+export function getNetwork(network?: Network): BlsNetwork {
+  if (network === undefined) {
+    // Return default network
+    return localhost
+  }
+  if (network?.type === 'bls') {
+    return network as BlsNetwork
   }
   throw new Error('Unsupported network')
 }

--- a/ethdk/src/Bls/BlsNetworks.ts
+++ b/ethdk/src/Bls/BlsNetworks.ts
@@ -11,11 +11,12 @@ export const localhost: BlsNetwork = {
 }
 
 export function getNetwork(network?: Network): BlsNetwork {
-  if (network === undefined) {
+  if (network === undefined || network === null) {
     // Return default network
     return localhost
   }
-  if (network?.type === 'bls') {
+
+  if (network.type === 'bls') {
     return network as BlsNetwork
   }
   throw new Error('Unsupported network')

--- a/ethdk/src/Bls/BlsTransaction.ts
+++ b/ethdk/src/Bls/BlsTransaction.ts
@@ -4,7 +4,7 @@ import {
   type BundleReceiptError,
 } from 'bls-wallet-clients/dist/src/Aggregator'
 import type Transaction from '../interfaces/Transaction'
-import type { BlsNetwork } from '../interfaces/Network'
+import { type BlsNetwork, type Network } from '../interfaces/Network'
 import { getNetwork } from './BlsNetworks'
 
 type ReceiptResponse = BundleReceipt | BundleReceiptError
@@ -17,7 +17,7 @@ export default class BlsTransaction implements Transaction {
     network,
   }: {
     bundleHash: string
-    network: string
+    network: Network
   }) {
     this.network = getNetwork(network)
     this.hash = bundleHash

--- a/ethdk/src/Ethdk.ts
+++ b/ethdk/src/Ethdk.ts
@@ -1,9 +1,10 @@
+import { type Network } from './interfaces/Network'
 import BlsAccount from './Bls/BlsAccount'
 
 interface AccountConfig {
   accountType: 'bls' | 'eoa'
   privateKey?: string
-  network?: string
+  network?: Network
 }
 
 interface AccountTypeMap {

--- a/ethdk/src/Networks/index.ts
+++ b/ethdk/src/Networks/index.ts
@@ -1,0 +1,7 @@
+import { localhost } from '../Bls/BlsNetworks'
+
+export const BLS_NETWORKS = {
+  localhost,
+}
+
+export const EOA_NETWORKS = {}

--- a/ethdk/src/index.ts
+++ b/ethdk/src/index.ts
@@ -1,5 +1,6 @@
 import { createAccount } from './Ethdk'
 import BlsAccount from './Bls/BlsAccount'
 import BlsTransaction from './Bls/BlsTransaction'
+import * as networks from './Networks'
 
-export { createAccount, BlsAccount, BlsTransaction }
+export { createAccount, BlsAccount, BlsTransaction, networks }

--- a/ethdk/src/interfaces/Network.ts
+++ b/ethdk/src/interfaces/Network.ts
@@ -1,10 +1,12 @@
 export interface Network {
+  type: string
   name: string
   chainId: number
   rpcUrl: string
 }
 
 export interface BlsNetwork extends Network {
+  type: 'bls'
   aggregatorUrl: string
   verificationGateway: string
   aggregatorUtilities: string

--- a/ethdk/test/BlsAccount.test.ts
+++ b/ethdk/test/BlsAccount.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import { describe, it, afterEach } from 'mocha'
 import BlsAccount from '../src/Bls/BlsAccount'
 import BlsTransaction from '../src/Bls/BlsTransaction'
+import { BLS_NETWORKS } from '../src/Networks'
 import sinon from 'sinon'
 
 import { ethers } from 'ethers'
@@ -23,7 +24,7 @@ describe('BlsAccount', () => {
 
       const accountConfig = {
         privateKey,
-        network: 'localhost',
+        network: BLS_NETWORKS.localhost,
       }
       const account = await BlsAccount.createAccount(accountConfig)
 
@@ -76,7 +77,7 @@ describe('BlsAccount', () => {
 
     const accountConfig = {
       privateKey: '0x123',
-      network: 'localhost',
+      network: BLS_NETWORKS.localhost,
     }
     const account = await BlsAccount.createAccount(accountConfig)
 
@@ -109,7 +110,7 @@ describe('BlsAccount', () => {
         .returns(mockAggregator)
       const accountConfig = {
         privateKey: '0x123',
-        network: 'localhost',
+        network: BLS_NETWORKS.localhost,
       }
       const account = await BlsAccount.createAccount(accountConfig)
 
@@ -151,7 +152,7 @@ describe('BlsAccount', () => {
 
       const accountConfig = {
         privateKey: '0x123',
-        network: 'localhost',
+        network: BLS_NETWORKS.localhost,
       }
       const account = await BlsAccount.createAccount(accountConfig)
 
@@ -190,7 +191,7 @@ describe('BlsAccount', () => {
         .resolves(mockAddress)
       const accountConfig = {
         privateKey: '0x123',
-        network: 'localhost',
+        network: BLS_NETWORKS.localhost,
       }
       const account = await BlsAccount.createAccount(accountConfig)
       const result = await account.getBalance()

--- a/ethdk/test/BlsTransaction.test.ts
+++ b/ethdk/test/BlsTransaction.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 import { Aggregator } from 'bls-wallet-clients'
 import BlsTransaction from '../src/Bls/BlsTransaction'
+import { BLS_NETWORKS } from '../src/Networks'
 
 describe('BlsTransaction', () => {
   afterEach(() => {
@@ -24,7 +25,7 @@ describe('BlsTransaction', () => {
         .returns(mockAggregator as any)
 
       const transaction = new BlsTransaction({
-        network: 'localhost',
+        network: BLS_NETWORKS.localhost,
         bundleHash,
       })
 


### PR DESCRIPTION
Cleaning up the network config a little so that now we can just pass around a network object, rather than having to do a lookup for the config based on a string.

Now we can do
```typescript
import { networks, createAccount } from 'ethdk'

const account = createAccount({
   accountType: 'bls',   
   privateKey,
   network: networks.BLS_NETWORKS.localhost,
})
```

We can also pass a custom network if we want now
```typescript
const account = await createAccount({
    accountType: 'bls',
    privateKey: useLocalStore.getState().privateKey,
    network: {
      type: 'bls',
      name: 'localhost',
      chainId: 1337,
      rpcUrl: 'http://localhost:8545',
      aggregatorUtilities: '0x76cE3c1F2E6d87c355560fCbd28ccAcAe03f95F6',
      verificationGateway: '0x689A095B4507Bfa302eef8551F90fB322B3451c6',
      aggregatorUrl: 'http://localhost:3000',
    } as BlsNetwork,
  });
```

If we start to get a lot of networks it would be nice if we could do this to get the configs (for tree shaking), I just haven't figured out how to get it to work yet.

```typescript
import { localhost } from 'ethdk/networks/bls'
```