### PR TITLE
Add an account abstraction account

### DIFF
--- a/ethdk/package.json
+++ b/ethdk/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
+    "@account-abstraction/sdk": "^0.5.0",
     "bls-wallet-clients": "0.8.2-1452ef5",
     "ethers": "^5.7.2"
   },

--- a/ethdk/src/AccountAbstraction/AccountAbstractionAccount.ts
+++ b/ethdk/src/AccountAbstraction/AccountAbstractionAccount.ts
@@ -65,14 +65,7 @@ export default class AccountAbstractionAccount implements Account {
         ? Wallet.createRandom()
         : new Wallet(privateKey, provider)
 
-    const aaProvider = await wrapProvider(
-      provider,
-      {
-        entryPointAddress: networkConfig.entryPointAddress,
-        bundlerUrl: networkConfig.bundlerUrl,
-      },
-      signer,
-    )
+    const aaProvider = await this.getAaProvider(provider, signer, networkConfig)
 
     return new AccountAbstractionAccount({
       address: await aaProvider.getSigner().getAddress(),
@@ -104,5 +97,22 @@ export default class AccountAbstractionAccount implements Account {
   async getBalance(): Promise<string> {
     const balance = await this.aaProvider.getBalance(this.address)
     return ethers.utils.formatEther(balance)
+  }
+
+  // Creating a helper function to get the provider
+  // so we can mock the provider for testing
+  static async getAaProvider(
+    provider: ethers.providers.JsonRpcProvider,
+    signer: ethers.Signer,
+    networkConfig: AccountAbstractionNetwork,
+  ): Promise<aaSdk.ERC4337EthersProvider> {
+    return await aaSdk.wrapProvider(
+      provider,
+      {
+        entryPointAddress: networkConfig.entryPointAddress,
+        bundlerUrl: networkConfig.bundlerUrl,
+      },
+      signer,
+    )
   }
 }

--- a/ethdk/src/AccountAbstraction/AccountAbstractionAccount.ts
+++ b/ethdk/src/AccountAbstraction/AccountAbstractionAccount.ts
@@ -6,10 +6,12 @@ import {
 import { ethers, Wallet } from 'ethers'
 
 import type Account from '../interfaces/Account'
-import { type TransactionRequest } from '@ethersproject/abstract-provider'
 import { type Deferrable } from 'ethers/lib/utils'
 import type Transaction from '../interfaces/Transaction'
-import { type AccountAbstractionNetwork } from '../interfaces/Network'
+import {
+  type Network,
+  type AccountAbstractionNetwork,
+} from '../interfaces/Network'
 import { getNetwork } from './AccountAbstractionNetworks'
 import AccountAbstractionTransaction from './AccountAbstractionTransaction'
 
@@ -47,7 +49,7 @@ export default class AccountAbstractionAccount implements Account {
     network,
   }: {
     privateKey?: string
-    network?: AccountAbstractionNetwork
+    network?: Network
   }): Promise<AccountAbstractionAccount> {
     const networkConfig = getNetwork(network)
 
@@ -82,12 +84,25 @@ export default class AccountAbstractionAccount implements Account {
   }
 
   async sendTransaction(
-    transaction: Deferrable<TransactionRequest>,
+    transaction: Deferrable<ethers.providers.TransactionRequest>,
   ): Promise<Transaction> {
     const response = await this.aaSigner.sendTransaction(transaction)
     return new AccountAbstractionTransaction({
       hash: response.hash,
       network: this.networkConfig,
     })
+  }
+
+  static async generatePrivateKey(): Promise<string> {
+    return Wallet.createRandom().privateKey
+  }
+
+  /**
+   * Get the balance of this account
+   * @returns The balance of this account formated in ether (instead of wei)
+   */
+  async getBalance(): Promise<string> {
+    const balance = await this.aaProvider.getBalance(this.address)
+    return ethers.utils.formatEther(balance)
   }
 }

--- a/ethdk/src/AccountAbstraction/AccountAbstractionAccount.ts
+++ b/ethdk/src/AccountAbstraction/AccountAbstractionAccount.ts
@@ -105,8 +105,8 @@ export default class AccountAbstractionAccount implements Account {
     provider: ethers.providers.JsonRpcProvider,
     signer: ethers.Signer,
     networkConfig: AccountAbstractionNetwork,
-  ): Promise<aaSdk.ERC4337EthersProvider> {
-    return await aaSdk.wrapProvider(
+  ): Promise<ERC4337EthersProvider> {
+    return await wrapProvider(
       provider,
       {
         entryPointAddress: networkConfig.entryPointAddress,

--- a/ethdk/src/AccountAbstraction/AccountAbstractionAccount.ts
+++ b/ethdk/src/AccountAbstraction/AccountAbstractionAccount.ts
@@ -50,7 +50,7 @@ export default class AccountAbstractionAccount implements Account {
   }: {
     privateKey?: string
     network?: Network
-  }): Promise<AccountAbstractionAccount> {
+  } = {}): Promise<AccountAbstractionAccount> {
     const networkConfig = getNetwork(network)
 
     const provider = new ethers.providers.JsonRpcProvider(

--- a/ethdk/src/AccountAbstraction/AccountAbstractionNetworks.ts
+++ b/ethdk/src/AccountAbstraction/AccountAbstractionNetworks.ts
@@ -8,8 +8,8 @@ export const localhost: AccountAbstractionNetwork = {
   name: 'localhost',
   chainId: 1337,
   rpcUrl: 'http://localhost:8545',
-  bundlerUrl: 'http://localhost:3000',
-  entryPointAddress: '0x689A095B4507Bfa302eef8551F90fB322B3451c6',
+  bundlerUrl: 'http://localhost:3000/rpc',
+  entryPointAddress: '0x0576a174d229e3cfa37253523e645a78a0c91b57',
 }
 
 export function getNetwork(network?: Network): AccountAbstractionNetwork {

--- a/ethdk/src/AccountAbstraction/AccountAbstractionNetworks.ts
+++ b/ethdk/src/AccountAbstraction/AccountAbstractionNetworks.ts
@@ -1,0 +1,25 @@
+import {
+  type Network,
+  type AccountAbstractionNetwork,
+} from '../interfaces/Network'
+
+export const localhost: AccountAbstractionNetwork = {
+  type: 'aa',
+  name: 'localhost',
+  chainId: 1337,
+  rpcUrl: 'http://localhost:8545',
+  bundlerUrl: 'http://localhost:3000',
+  entryPointAddress: '0x689A095B4507Bfa302eef8551F90fB322B3451c6',
+}
+
+export function getNetwork(network?: Network): AccountAbstractionNetwork {
+  if (network === undefined || network === null) {
+    // Return default network
+    return localhost
+  }
+
+  if (network.type === 'aa') {
+    return network as AccountAbstractionNetwork
+  }
+  throw new Error('Unsupported network')
+}

--- a/ethdk/src/AccountAbstraction/AccountAbstractionTransaction.ts
+++ b/ethdk/src/AccountAbstraction/AccountAbstractionTransaction.ts
@@ -1,0 +1,24 @@
+import { ethers } from 'ethers'
+import type Transaction from '../interfaces/Transaction'
+import {
+  type AccountAbstractionNetwork,
+  type Network,
+} from '../interfaces/Network'
+import { getNetwork } from './AccountAbstractionNetworks'
+
+type ReceiptResponse = ethers.providers.TransactionReceipt
+
+export default class AccountAbstractionTransaction implements Transaction {
+  hash: string
+  network: AccountAbstractionNetwork
+
+  constructor({ hash, network }: { hash: string; network: Network }) {
+    this.network = getNetwork(network)
+    this.hash = hash
+  }
+
+  async getTransactionReceipt(): Promise<ReceiptResponse | undefined> {
+    const provider = new ethers.providers.JsonRpcProvider(this.network.rpcUrl)
+    return await provider.getTransactionReceipt(this.hash)
+  }
+}

--- a/ethdk/src/Ethdk.ts
+++ b/ethdk/src/Ethdk.ts
@@ -1,14 +1,16 @@
 import { type Network } from './interfaces/Network'
 import BlsAccount from './Bls/BlsAccount'
+import AccountAbstractionAccount from './AccountAbstraction/AccountAbstractionAccount'
 
 interface AccountConfig {
-  accountType: 'bls' | 'eoa'
+  accountType: 'bls' | 'eoa' | 'aa'
   privateKey?: string
   network?: Network
 }
 
 interface AccountTypeMap {
   bls: BlsAccount
+  aa: AccountAbstractionAccount
   // Add more types as needed
 }
 
@@ -27,6 +29,13 @@ export async function createAccount<T extends keyof AccountTypeMap>({
 }: AccountConfig & { accountType: T }): Promise<AccountTypeToReturnType<T>> {
   if (accountType === 'bls') {
     const account = await BlsAccount.createAccount({
+      privateKey,
+      network,
+    })
+    return account as AccountTypeToReturnType<T>
+  }
+  if (accountType === 'aa') {
+    const account = await AccountAbstractionAccount.createAccount({
       privateKey,
       network,
     })

--- a/ethdk/src/Networks/index.ts
+++ b/ethdk/src/Networks/index.ts
@@ -1,7 +1,12 @@
-import { localhost } from '../Bls/BlsNetworks'
+import * as aa from '../AccountAbstraction/AccountAbstractionNetworks'
+import * as bls from '../Bls/BlsNetworks'
 
 export const BLS_NETWORKS = {
-  localhost,
+  localhost: bls.localhost,
 }
 
 export const EOA_NETWORKS = {}
+
+export const AA_NETWORKS = {
+  localhost: aa.localhost,
+}

--- a/ethdk/src/index.ts
+++ b/ethdk/src/index.ts
@@ -1,6 +1,15 @@
 import { createAccount } from './Ethdk'
 import BlsAccount from './Bls/BlsAccount'
 import BlsTransaction from './Bls/BlsTransaction'
+import AccountAbstractionAccount from './AccountAbstraction/AccountAbstractionAccount'
+import AccountAbstractionTransaction from './AccountAbstraction/AccountAbstractionTransaction'
 import * as networks from './Networks'
 
-export { createAccount, BlsAccount, BlsTransaction, networks }
+export {
+  createAccount,
+  BlsAccount,
+  BlsTransaction,
+  networks,
+  AccountAbstractionAccount,
+  AccountAbstractionTransaction,
+}

--- a/ethdk/src/interfaces/Network.ts
+++ b/ethdk/src/interfaces/Network.ts
@@ -11,3 +11,9 @@ export interface BlsNetwork extends Network {
   verificationGateway: string
   aggregatorUtilities: string
 }
+
+export interface AccountAbstractionNetwork extends Network {
+  type: 'aa'
+  entryPointAddress: string
+  bundlerUrl: string
+}

--- a/ethdk/test/AccountAbstraction/AccountAbstractionAccount.test.ts
+++ b/ethdk/test/AccountAbstraction/AccountAbstractionAccount.test.ts
@@ -1,0 +1,159 @@
+import { expect } from 'chai'
+import { describe, it, afterEach } from 'mocha'
+import sinon from 'sinon'
+
+import { ethers, Wallet } from 'ethers'
+import AccountAbstractionAccount from '../../src/AccountAbstraction/AccountAbstractionAccount'
+import { localhost } from '../../src/AccountAbstraction/AccountAbstractionNetworks'
+import AccountAbstractionTransaction from '../../src/AccountAbstraction/AccountAbstractionTransaction'
+import * as networkModule from '../../src/AccountAbstraction/AccountAbstractionNetworks'
+
+describe('AccountAbstractionAccount', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('createAccount', () => {
+    it('should create an account with a given private key', async () => {
+      // Arrange
+      const privateKey =
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+      const smartContractAddress = '0xabcd6Ef563a5c06d6755849c3e27116fcCa4B33f'
+      sinon.createStubInstance(Wallet)
+      const mockAaProvider = {
+        getSigner: sinon.stub().returns({
+          getAddress: sinon.stub().resolves(smartContractAddress),
+        }),
+      }
+      sinon
+        .stub(AccountAbstractionAccount, 'getAaProvider')
+        .resolves(mockAaProvider as any)
+      const getNetworkSpy = sinon.spy(networkModule, 'getNetwork')
+
+      // Act
+      const accountConfig = {
+        privateKey,
+        network: localhost,
+      }
+      const account = await AccountAbstractionAccount.createAccount(
+        accountConfig,
+      )
+
+      // Assert
+      expect(account).to.be.instanceOf(AccountAbstractionAccount)
+      expect(account.address).to.equal(smartContractAddress)
+      expect(getNetworkSpy.calledOnceWith(localhost)).to.equal(true)
+    })
+
+    it('should create an account with a generated private key', async () => {
+      // Arrange
+      const privateKey =
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+      const smartContractAddress = '0x12346Ef563a5c06d6755849c3e27116fcCa4B33f'
+      sinon.createStubInstance(Wallet)
+      const mockAaProvider = {
+        getSigner: sinon.stub().returns({
+          getAddress: sinon.stub().resolves(smartContractAddress),
+        }),
+      }
+      sinon
+        .stub(AccountAbstractionAccount, 'getAaProvider')
+        .resolves(mockAaProvider as any)
+
+      const walletStub = sinon
+        .stub(Wallet, 'createRandom')
+        .returns(new Wallet(privateKey))
+
+      // Act
+      const account = await AccountAbstractionAccount.createAccount({})
+
+      // Assert
+      expect(account).to.be.instanceOf(AccountAbstractionAccount)
+      expect(account.address).to.equal(smartContractAddress)
+      expect(walletStub.calledOnce).to.equal(true)
+    })
+  })
+
+  describe('generatePrivateKey', () => {
+    it('should return a generated private key', async () => {
+      // Arrange
+      const privateKey =
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+
+      sinon.stub(Wallet, 'createRandom').returns(new Wallet(privateKey))
+
+      // Act
+      const result = await AccountAbstractionAccount.generatePrivateKey()
+
+      // Assert
+      expect(result).to.equal(privateKey)
+    })
+  })
+
+  it('should send a transaction successfully', async () => {
+    // Arrange
+    const mockTransactionResponse = { hash: '0x67890' }
+    const smartContractAddress = '0x12346Ef563a5c06d6755849c3e27116fcCa4B33f'
+    sinon.createStubInstance(Wallet)
+    const mockAaProvider = {
+      getSigner: sinon.stub().returns({
+        getAddress: sinon.stub().resolves(smartContractAddress),
+        sendTransaction: sinon.stub().resolves(mockTransactionResponse),
+      }),
+    }
+    sinon
+      .stub(AccountAbstractionAccount, 'getAaProvider')
+      .resolves(mockAaProvider as any)
+
+    const accountConfig = {
+      privateKey:
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      network: localhost,
+    }
+    const account = await AccountAbstractionAccount.createAccount(accountConfig)
+
+    // Act
+    const transactionParams = {
+      to: '0x12345',
+      value: '0',
+      data: '0x',
+    }
+    const transaction = await account.sendTransaction(transactionParams)
+
+    // Assert
+    expect(transaction).to.be.instanceOf(AccountAbstractionTransaction)
+    expect(transaction.hash).to.equal(mockTransactionResponse.hash)
+  })
+
+  describe('getBalance', () => {
+    it('should get the balance of an account successfully', async () => {
+      // Arrange
+      const balance = ethers.utils.parseEther('1.23')
+      const smartContractAddress = '0x12346Ef563a5c06d6755849c3e27116fcCa4B33f'
+      sinon.createStubInstance(Wallet)
+      const mockAaProvider = {
+        getSigner: sinon.stub().returns({
+          getAddress: sinon.stub().resolves(smartContractAddress),
+        }),
+        getBalance: sinon.stub().resolves(balance),
+      }
+      sinon
+        .stub(AccountAbstractionAccount, 'getAaProvider')
+        .resolves(mockAaProvider as any)
+      const accountConfig = {
+        privateKey:
+          '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        network: localhost,
+      }
+      const account = await AccountAbstractionAccount.createAccount(
+        accountConfig,
+      )
+
+      // Act
+      const result = await account.getBalance()
+
+      // Assert
+      expect(result).to.equal('1.23')
+    })
+  })
+})

--- a/ethdk/test/AccountAbstraction/AccountAbstractionAccount.test.ts
+++ b/ethdk/test/AccountAbstraction/AccountAbstractionAccount.test.ts
@@ -65,7 +65,7 @@ describe('AccountAbstractionAccount', () => {
         .returns(new Wallet(privateKey))
 
       // Act
-      const account = await AccountAbstractionAccount.createAccount({})
+      const account = await AccountAbstractionAccount.createAccount()
 
       // Assert
       expect(account).to.be.instanceOf(AccountAbstractionAccount)

--- a/ethdk/test/AccountAbstraction/AccountAbstractionNetwork.test.ts
+++ b/ethdk/test/AccountAbstraction/AccountAbstractionNetwork.test.ts
@@ -30,7 +30,7 @@ describe('getNetwork', () => {
     expect(resultNetwork).to.deep.equal(expectedNetwork)
   })
 
-  it('should return the ExternallyOwnedAccountNetwork when network type is eoa', () => {
+  it('should return the ExternallyOwnedAccountNetwork when network type is aa', () => {
     // Arrange
     const expectedNetwork = {
       type: 'aa',
@@ -48,7 +48,7 @@ describe('getNetwork', () => {
     expect(resultNetwork).to.deep.equal(expectedNetwork)
   })
 
-  it('should throw an error when network type is not eoa', () => {
+  it('should throw an error when network type is not aa', () => {
     // Arrange
     const network = {
       type: 'unsupported',

--- a/ethdk/test/AccountAbstraction/AccountAbstractionNetwork.test.ts
+++ b/ethdk/test/AccountAbstraction/AccountAbstractionNetwork.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { AA_NETWORKS } from '../../src/Networks'
+import { getNetwork } from '../../src/AccountAbstraction/AccountAbstractionNetworks'
+
+describe('getNetwork', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should return the default network when network is undefined', () => {
+    // Arrange
+    const expectedNetwork = AA_NETWORKS.localhost
+
+    // Act
+    const resultNetwork = getNetwork(undefined)
+
+    // Assert
+    expect(resultNetwork).to.deep.equal(expectedNetwork)
+  })
+
+  it('should return the default network when network is null', () => {
+    // Arrange
+    const expectedNetwork = AA_NETWORKS.localhost
+
+    // Act
+    const resultNetwork = getNetwork(null as any)
+
+    // Assert
+    expect(resultNetwork).to.deep.equal(expectedNetwork)
+  })
+
+  it('should return the ExternallyOwnedAccountNetwork when network type is eoa', () => {
+    // Arrange
+    const expectedNetwork = {
+      type: 'aa',
+      name: 'localhost',
+      chainId: 1337,
+      rpcUrl: 'http://localhost:8545',
+      bundlerUrl: 'http://localhost:3000/rpc',
+      entryPointAddress: '0x0576a174d229e3cfa37253523e645a78a0c91b57',
+    }
+
+    // Act
+    const resultNetwork = getNetwork(AA_NETWORKS.localhost)
+
+    // Assert
+    expect(resultNetwork).to.deep.equal(expectedNetwork)
+  })
+
+  it('should throw an error when network type is not eoa', () => {
+    // Arrange
+    const network = {
+      type: 'unsupported',
+      name: 'testnet',
+      chainId: 1234,
+      rpcUrl: 'http://localhost:1234',
+    }
+
+    // Act & Assert
+    expect(() => getNetwork(network)).to.throw('Unsupported network')
+  })
+})

--- a/ethdk/test/AccountAbstraction/AccountAbstractionTransaction.test.ts
+++ b/ethdk/test/AccountAbstraction/AccountAbstractionTransaction.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai'
+import { ethers } from 'ethers'
+import sinon from 'sinon'
+import AccountAbstractionTransaction from '../../src/AccountAbstraction/AccountAbstractionTransaction'
+import { AA_NETWORKS } from '../../src/Networks'
+
+describe('AccountAbstractionTransaction', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('getTransactionReceipt', () => {
+    it('should return the transaction receipt', async () => {
+      // Arrange
+      const hash = 'testHash'
+      const mockReceipt: any = {
+        hash,
+      }
+
+      const getTransactionReceiptStub = sinon.stub(
+        ethers.providers.JsonRpcProvider.prototype,
+        'getTransactionReceipt',
+      )
+
+      getTransactionReceiptStub.resolves(mockReceipt)
+
+      const transaction = new AccountAbstractionTransaction({
+        network: AA_NETWORKS.localhost,
+        hash,
+      })
+
+      // Act
+      const receipt = await transaction.getTransactionReceipt()
+
+      // Assert
+      expect(receipt).to.deep.equal(mockReceipt)
+      expect(getTransactionReceiptStub.calledOnceWith(hash)).to.equal(true)
+    })
+  })
+})

--- a/ethdk/yarn.lock
+++ b/ethdk/yarn.lock
@@ -2,6 +2,39 @@
 # yarn lockfile v1
 
 
+"@account-abstraction/contracts@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@account-abstraction/contracts/-/contracts-0.5.0.tgz#a089aee7b4c446251fbbce7df315bbf8f659e37f"
+  integrity sha512-CKyS9Zh5rcYUM+4B6TlaB9+THHzJ+6TY3tWF5QofqvFpqGNvIhF8ddy6wyCmqZw6TB74/yYv7cYD/RarVudfDg==
+
+"@account-abstraction/sdk@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@account-abstraction/sdk/-/sdk-0.5.0.tgz#fb306ecb1dba82e10a0277ab716890acf1d2d1ed"
+  integrity sha512-KuEG9UVl2kEhamevFmPJfqY5AQH4fRLnFhfWAdoqwxIZIuSyA8wfyzM9WKnDPSCaiApLvSzckjRwbs4dVoOp2Q==
+  dependencies:
+    "@account-abstraction/contracts" "^0.5.0"
+    "@account-abstraction/utils" "^0.5.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/providers" "^5.7.0"
+    "@types/debug" "^4.1.7"
+    debug "^4.3.4"
+    ethers "^5.7.0"
+
+"@account-abstraction/utils@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@account-abstraction/utils/-/utils-0.5.0.tgz#aa7925741048b1657a71d7f98ccaf3c187f99b4a"
+  integrity sha512-dgXguTn5WgFMmr3wQMdLGEoIMDcIJgzAv74YlHeb2D3Nyy1pByPArSb3eLOOcgxCJSJeqTscpO9P57uhNkkC4A==
+  dependencies:
+    "@account-abstraction/contracts" "^0.5.0"
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/providers" "^5.7.0"
+    "@openzeppelin/contracts" "^4.7.3"
+    debug "^4.3.4"
+    ethers "^5.7.0"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -232,7 +265,7 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/providers@5.7.2":
+"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.7.0":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
   integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
@@ -441,6 +474,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@openzeppelin/contracts@^4.7.3":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.2.tgz#d815ade0027b50beb9bcca67143c6bcc3e3923d6"
+  integrity sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g==
+
 "@sinonjs/commons@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
@@ -516,6 +554,13 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.4.tgz#e913e8175db8307d78b4e8fa690408ba6b65dee4"
   integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
 
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -530,6 +575,11 @@
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.1.tgz#2f4f65bb08bc368ac39c96da7b2f09140b26851b"
   integrity sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/semver@^7.3.12":
   version "7.3.13"
@@ -1321,7 +1371,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethers@^5.5.3, ethers@^5.7.2:
+ethers@^5.5.3, ethers@^5.7.0, ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==


### PR DESCRIPTION
Using eth-infinitism implementation of a 4337 account to add an AA account to ethdk.

The sdk used to create a signer/provider is `@account-abstraction/sdk`

I also tested running their contracts and bundler here https://github.com/eth-infinitism/bundler

Note: I haven't gotten a transaction working yet.  However, I believe it is likely due to my bundler setup so I am still working on that.  Wanted to get this in though as I believe the code is set up correctly.